### PR TITLE
Ensures we are using pip3 to prevent the following error:

### DIFF
--- a/userdata-cloud-init-multimime.txt.template
+++ b/userdata-cloud-init-multimime.txt.template
@@ -68,7 +68,7 @@ packages:
  - puppet
  - ruby # Used to install librarian-puppet
  - ruby-dev
- - python-pip # Used to install awscli
+ - python3-pip # Used to install awscli
 
 # run commands
 # runcmd contains a list of either lists or a string
@@ -81,7 +81,8 @@ runcmd:
  # Tell sudo to respect SSH Agent forwarding
  - [sh, -c, "umask 0226; echo 'Defaults env_keep += \"SSH_AUTH_SOCK\"' > /etc/sudoers.d/ssh-auth-sock"]
  # Install AWS CLI
- - pip install awscli
+ - pip3 install typing 
+ - pip3 install awscli
  # Install librarian-puppet for retrieving dependent puppet modules from github (>1.0.3 requires >=Ruby 1.9)
  - gem install highline --version 1.6.1
  - gem install json --version 1.8.3


### PR DESCRIPTION
"Could not find any downloads that satisfy the requirement awscli"